### PR TITLE
Use proper base in links

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -6,5 +6,5 @@ import mdx from '@astrojs/mdx';
 export default defineConfig({
   integrations: [preact(), react(), mdx()],
   site: `https://wevisdemo.github.io`,
-  base: process.env.PUBLIC_ASTRO_BASE || '/',
+  base: import.meta.env.PUBLIC_ASTRO_BASE ?? '/',
 });

--- a/docs/src/components/HeadCommon.astro
+++ b/docs/src/components/HeadCommon.astro
@@ -8,9 +8,7 @@ import '../styles/index.css';
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />
 
-<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-
-<link rel="sitemap" href="/sitemap.xml" />
+<link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
 
 <!-- Preload Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/docs/src/components/Header/Header.astro
+++ b/docs/src/components/Header/Header.astro
@@ -16,7 +16,7 @@ type Props = {
       <SidebarToggle client:idle />
     </div>
     <div class="logo flex">
-      <a href="/">
+      <a href={import.meta.env.BASE_URL}>
         <h1>{CONFIG.SITE.title ?? 'Documentation'}</h1>
       </a>
     </div>

--- a/docs/src/components/LeftSidebar/LeftSidebar.astro
+++ b/docs/src/components/LeftSidebar/LeftSidebar.astro
@@ -19,17 +19,17 @@ const currentPageMatch = currentPage.endsWith('/')
             <h4>{header}</h4>
             <ul>
               {children.map((child) => (
-                  <li class="nav-link">
-                    <a
-                      href={`${process.env.PUBLIC_ASTRO_BASE || ''}/${child.link}`}
-                      aria-current={
-                        currentPageMatch === child.link ? 'page' : false
-                      }
-                    >
-                      {child.text}
-                    </a>
-                  </li>
-                ))}
+                <li class="nav-link">
+                  <a
+                    href={`${import.meta.env.BASE_URL}${child.link}`}
+                    aria-current={
+                      currentPageMatch === child.link ? 'page' : false
+                    }
+                  >
+                    {child.text}
+                  </a>
+                </li>
+              ))}
             </ul>
           </div>
         </li>


### PR DESCRIPTION
- Append `${import.meta.env.BASE_URL}` to URLs to make it behave correctly on base change (such as in production)
- Use `import.meta.env` instead of `process.env`
- Remove `<link rel="sitemap" href="/sitemap.xml" />` since there is no sitemap generator

PS: I have tried to specify `base` in many ways such as `''`, `'lol'`, `'/lol'`, `'lol/'`, `'/lol/'`. Apparently, all will be transformed into a proper URL, `'/'` and `'/lol/'`. So there is no need in using `/` between `import.meta.env.BASE_URL` and the path.