### PR TITLE
fix: use `process.env` in astro config

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -6,5 +6,5 @@ import mdx from '@astrojs/mdx';
 export default defineConfig({
   integrations: [preact(), react(), mdx()],
   site: `https://wevisdemo.github.io`,
-  base: import.meta.env.PUBLIC_ASTRO_BASE ?? '/',
+  base: process.env.PUBLIC_ASTRO_BASE ?? '/',
 });


### PR DESCRIPTION
My bad that I didn't read Astro docs thoroughly. Here is a fix for the docs ❤️‍🩹.